### PR TITLE
Fixing handling non-integer sizes

### DIFF
--- a/lib/filesize.rb
+++ b/lib/filesize.rb
@@ -103,7 +103,7 @@ class Filesize
       }
 
       prefix = $2 || ''
-      size   = ($1 || "0").gsub(", ", "").to_i
+      size   = ($1 || "0").gsub(", ", "").to_f
 
       return { :prefix => prefix, :size => size, :type => type}
     end


### PR DESCRIPTION
There was an error in handling non-integer sizes:

> > Filesize.from('1.5 kB').to_i
> >    => 1000

Please update gem, if it possible.
