### PR TITLE
Support unit without B suffix

### DIFF
--- a/lib/filesize.rb
+++ b/lib/filesize.rb
@@ -13,14 +13,14 @@ class Filesize
 
   # Set of rules describing file sizes according to SI units.
   SI = {
-    :regexp => /^([\d,.]+)?[[:space:]]?([kmgtpezy]?)b$/i,
+    :regexp => /^([\d,.]+)?[[:space:]]?([kmgtpezy]?)b?$/i,
     :multiplier => 1000,
     :prefixes => TYPE_PREFIXES[:SI],
     :presuffix => '' # deprecated
   }
   # Set of rules describing file sizes according to binary units.
   BINARY = {
-    :regexp => /^([\d,.]+)?[[:space:]]?(?:([kmgtpezy])i)?b$/i,
+    :regexp => /^([\d,.]+)?[[:space:]]?(?:([kmgtpezy])i)?b?$/i,
     :multiplier => 1024,
     :prefixes => TYPE_PREFIXES[:BINARY],
     :presuffix => 'i' # deprecated

--- a/spec/lib/filesize_spec.rb
+++ b/spec/lib/filesize_spec.rb
@@ -38,6 +38,10 @@ describe Filesize do
       it 'parses megabytes' do
         expect(Filesize.from('1 MB').to).to eq 1000 * 1000
       end
+
+      it 'parses megabytes without b suffix' do
+        expect(Filesize.from('1 M').to).to eq 1000 * 1000
+      end
     end
 
     context 'BINARY units' do
@@ -47,6 +51,10 @@ describe Filesize do
 
       it 'parses megabytes' do
         expect(Filesize.from('1 MiB').to).to eq 1024 * 1024
+      end
+
+      it 'parses mebibytes without b suffix' do
+        expect(Filesize.from('1 Mi').to).to eq 1024 * 1024
       end
     end
   end


### PR DESCRIPTION
e.g. Kubernetes uses this format: https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/#memory-units